### PR TITLE
com.tetris.shape.LeftTwoUp

### DIFF
--- a/2019-2-OSSPC-DURUNURI/TetrisNetwork/src/com/tetris/shape/LeftTwoUp.java
+++ b/2019-2-OSSPC-DURUNURI/TetrisNetwork/src/com/tetris/shape/LeftTwoUp.java
@@ -34,10 +34,10 @@ public class LeftTwoUp extends TetrisBlock implements Serializable{
 		this.rotation_index = rotation_index;
 		switch(rotation_index){
 		case ROTATION_0 : 
-			colBlock[3].setFixGridXY(-1,-1);
-			colBlock[2].setFixGridXY(0,-1);
-			colBlock[0].setFixGridXY(0,0);
-			colBlock[1].setFixGridXY(1,0);
+			colBlock[3].setFixGridXY(-1,0);
+			colBlock[2].setFixGridXY(0,0);
+			colBlock[0].setFixGridXY(0,1);
+			colBlock[1].setFixGridXY(1,1);
 			break;
 		case ROTATION_90 : 
 			colBlock[3].setFixGridXY(1,-1);


### PR DESCRIPTION
ROTATION_0 수정

테트리스창의 NEXT와 블록 미리보기창 쏠림현상해결을 해결하기 위함.