### PR TITLE
com.tetris.shape

### DIFF
--- a/2019-2-OSSPC-DURUNURI/TetrisNetwork/src/com/tetris/shape/Nemo.java
+++ b/2019-2-OSSPC-DURUNURI/TetrisNetwork/src/com/tetris/shape/Nemo.java
@@ -35,8 +35,8 @@ public class Nemo extends TetrisBlock implements Serializable {
 		this.rotation_index = rotation_index;
 		switch(rotation_index){
 		case ROTATION_0 : 
-			colBlock[2].setFixGridXY(0,-1);
-			colBlock[3].setFixGridXY(1,-1);
+			colBlock[2].setFixGridXY(0,1);
+			colBlock[3].setFixGridXY(1,1);
 			colBlock[0].setFixGridXY(0,0);
 			colBlock[1].setFixGridXY(1,0);
 			break;

--- a/2019-2-OSSPC-DURUNURI/TetrisNetwork/src/com/tetris/shape/RightTwoUp.java
+++ b/2019-2-OSSPC-DURUNURI/TetrisNetwork/src/com/tetris/shape/RightTwoUp.java
@@ -34,10 +34,10 @@ public class RightTwoUp extends TetrisBlock implements Serializable {
 		this.rotation_index = rotation_index;
 		switch(rotation_index){
 		case ROTATION_0 : 
-			colBlock[2].setFixGridXY(0,-1);
-			colBlock[3].setFixGridXY(1,-1);
-			colBlock[1].setFixGridXY(-1,0);
-			colBlock[0].setFixGridXY(0,0);
+			colBlock[2].setFixGridXY(0,0);
+			colBlock[3].setFixGridXY(1,0);
+			colBlock[1].setFixGridXY(-1,1);
+			colBlock[0].setFixGridXY(0,1);
 			break;
 		case ROTATION_90 : 
 			colBlock[3].setFixGridXY(-1,-1);


### PR DESCRIPTION
Nemo, RightTwoUp

ROTATION_0 수정

NEXT와 블록 미리보기창 쏠림현상해결을 해결하기 위함.